### PR TITLE
Add Qt GUI launcher

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.5)
+project(PulseToolGui)
+
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+set(CMAKE_AUTOUIC ON)
+
+find_package(Qt5 COMPONENTS Widgets REQUIRED)
+
+add_executable(pulsetool-gui
+    main.cpp
+    MainWindow.cpp
+)
+
+target_link_libraries(pulsetool-gui Qt5::Widgets)
+

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1,0 +1,83 @@
+#include "MainWindow.h"
+
+#include <QCoreApplication>
+#include <QMessageBox>
+#include <QProcess>
+#include <QPushButton>
+#include <QVBoxLayout>
+#include <QWidget>
+
+MainWindow::MainWindow(QWidget *parent)
+    : QMainWindow(parent)
+{
+    QWidget *central = new QWidget(this);
+    QVBoxLayout *layout = new QVBoxLayout(central);
+
+    QPushButton *baseBtn = new QPushButton(tr("Install Base Package"), this);
+    connect(baseBtn, &QPushButton::clicked, this, &MainWindow::runBasePackage);
+    layout->addWidget(baseBtn);
+
+    QPushButton *cannonBtn = new QPushButton(tr("Install Cannon Driver"), this);
+    connect(cannonBtn, &QPushButton::clicked, this, &MainWindow::runCannon);
+    layout->addWidget(cannonBtn);
+
+    QPushButton *fastfetchBtn = new QPushButton(tr("Run FastFetch"), this);
+    connect(fastfetchBtn, &QPushButton::clicked, this, &MainWindow::runFastFetch);
+    layout->addWidget(fastfetchBtn);
+
+    QPushButton *gameBtn = new QPushButton(tr("Install Game Package"), this);
+    connect(gameBtn, &QPushButton::clicked, this, &MainWindow::runGame);
+    layout->addWidget(gameBtn);
+
+    QPushButton *multimediaBtn = new QPushButton(tr("Install Multimedia Package"), this);
+    connect(multimediaBtn, &QPushButton::clicked, this, &MainWindow::runMultimedia);
+    layout->addWidget(multimediaBtn);
+
+    setCentralWidget(central);
+    setWindowTitle(tr("PulseTool GUI"));
+}
+
+void MainWindow::runScript(const QString &scriptName)
+{
+    QString scriptPath = QCoreApplication::applicationDirPath() + "/../" + scriptName;
+
+    QProcess process;
+    process.setProgram("bash");
+    process.setArguments({scriptPath});
+    process.start();
+    if (!process.waitForStarted()) {
+        QMessageBox::warning(this, tr("Error"), tr("Failed to start %1").arg(scriptName));
+        return;
+    }
+    process.waitForFinished(-1);
+
+    QString output = process.readAllStandardOutput();
+    QString errorOutput = process.readAllStandardError();
+    QMessageBox::information(this, tr("Finished"), output + errorOutput);
+}
+
+void MainWindow::runBasePackage()
+{
+    runScript("base-package.sh");
+}
+
+void MainWindow::runCannon()
+{
+    runScript("cannon.sh");
+}
+
+void MainWindow::runFastFetch()
+{
+    runScript("fastfetch.sh");
+}
+
+void MainWindow::runGame()
+{
+    runScript("game.sh");
+}
+
+void MainWindow::runMultimedia()
+{
+    runScript("multimedia.sh");
+}
+

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -1,0 +1,23 @@
+#ifndef MAINWINDOW_H
+#define MAINWINDOW_H
+
+#include <QMainWindow>
+
+class MainWindow : public QMainWindow
+{
+    Q_OBJECT
+public:
+    explicit MainWindow(QWidget *parent = nullptr);
+
+private slots:
+    void runBasePackage();
+    void runCannon();
+    void runFastFetch();
+    void runGame();
+    void runMultimedia();
+
+private:
+    void runScript(const QString &scriptName);
+};
+
+#endif // MAINWINDOW_H

--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -1,0 +1,11 @@
+#include <QApplication>
+
+#include "MainWindow.h"
+
+int main(int argc, char *argv[])
+{
+    QApplication app(argc, argv);
+    MainWindow w;
+    w.show();
+    return app.exec();
+}


### PR DESCRIPTION
## Summary
- add CMake-based Qt Widgets project under `src/gui`
- implement `MainWindow` with buttons to run existing shell scripts via `QProcess`
- provide entry point using `QApplication`
