### PR TITLE
Add Wayland session detection and display query

### DIFF
--- a/src/fastfetch.sh
+++ b/src/fastfetch.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+get_current_resolution() {
+    if [ -n "$WAYLAND_DISPLAY" ] && command -v wlr-randr >/dev/null 2>&1; then
+        wlr-randr --current | awk '/\*/ {print $1; exit}'
+    elif command -v xrandr >/dev/null 2>&1; then
+        xrandr | awk '/\*/ {print $1; exit}'
+    fi
+}
+
 install_fastfetch() {
     echo -e "                       \e[34m╭─────────────────────────────────────────────────╮\e[0m"
     echo -e "                       \e[34m|                                                 |\e[0m"
@@ -8,6 +16,9 @@ install_fastfetch() {
     echo -e "                       \e[34m|                                                 |\e[0m"
     echo -e "                       \e[34m|                                                 |\e[0m"
     echo -e "                       \e[34m╰─────────────────────────────────────────────────╯\e[0m"
+
+    current_res="$(get_current_resolution)"
+    [ -n "$current_res" ] && echo "Current display resolution: $current_res"
 
     # Update the package database and install FastFetch
     sudo pacman -Syu --noconfirm fastfetch

--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -1,10 +1,18 @@
 #include <QApplication>
+#include <QDebug>
 
 #include "MainWindow.h"
 
 int main(int argc, char *argv[])
 {
     QApplication app(argc, argv);
+
+    if (qEnvironmentVariableIsSet("WAYLAND_DISPLAY")) {
+        qDebug() << "WAYLAND_DISPLAY detected. Using Wayland session.";
+    } else {
+        qDebug() << "WAYLAND_DISPLAY not set. Falling back to X11 session.";
+    }
+
     MainWindow w;
     w.show();
     return app.exec();


### PR DESCRIPTION
## Summary
- Detect Wayland sessions at runtime in the Qt GUI
- Query monitor resolution using `wlr-randr` when Wayland is active, falling back to `xrandr` otherwise

